### PR TITLE
Update clusters.py

### DIFF
--- a/python/src/cm_api/endpoints/clusters.py
+++ b/python/src/cm_api/endpoints/clusters.py
@@ -82,6 +82,8 @@ class ApiCluster(BaseApiResource):
     'fullVersion'       : None,
     'maintenanceMode'   : ROAttr(),
     'maintenanceOwners' : ROAttr(),
+    'entityStatus' : ROAttr(),
+    'hostsUrl' : ROAttr(),
   }
 
   def __init__(self, resource_root, name=None, version=None, fullVersion=None):


### PR DESCRIPTION
for v11 API otherwise you get the below when you call get_all_clusters
AttributeError: Invalid property hostsUrl for class ApiCluster.
AttributeError: Invalid property entityStatus for class ApiCluster.