### PR TITLE
updating the version of Jackson to 2.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <cxf.version>2.7.7</cxf.version>
     <guava.version>14.0</guava.version>
-    <jackson2.version>2.1.0</jackson2.version>
+    <jackson2.version>2.7.0</jackson2.version>
     <joda.version>2.1</joda.version>
     <junit.version>4.11</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/java/src/main/java/com/cloudera/api/ApiObjectMapper.java
+++ b/java/src/main/java/com/cloudera/api/ApiObjectMapper.java
@@ -16,10 +16,11 @@
 
 package com.cloudera.api;
 
-import com.fasterxml.jackson.databind.AnnotationIntrospector;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 
 import java.text.DateFormat;
@@ -38,9 +39,9 @@ public class ApiObjectMapper extends ObjectMapper {
 
     // Allow JAX-B annotations.
     setAnnotationIntrospector(
-        new AnnotationIntrospector.Pair(
+        new AnnotationIntrospectorPair(
             getSerializationConfig().getAnnotationIntrospector(),
-            new JaxbAnnotationIntrospector()));
+            new JaxbAnnotationIntrospector(TypeFactory.defaultInstance())));
 
     // Make Jackson respect @XmlElementWrapper.
     enable(MapperFeature.USE_WRAPPER_NAME_AS_PROPERTY_NAME);


### PR DESCRIPTION
Jackson 2.1 is a pretty old version. Also, it appears that the CM is dependent upon a deprecated class which is not a great practice. These changes work and all tests pass.